### PR TITLE
Bug Fix: Microphone Stops Recording After ~10 Audios

### DIFF
--- a/src/flutter_sound_recorder.js
+++ b/src/flutter_sound_recorder.js
@@ -22,9 +22,6 @@ const IS_RECORDER_PAUSED = 1;
 const IS_RECORDER_RECORDING = 2;
 const IS_RECORDER_STOPPED = 0;
 
-const audioContext = new AudioContext();
-
-
 function newRecorderInstance(aCallback, callbackTable) { return new FlutterSoundRecorder(aCallback, callbackTable); }
 
 

--- a/src/flutter_sound_recorder.js
+++ b/src/flutter_sound_recorder.js
@@ -22,6 +22,9 @@ const IS_RECORDER_PAUSED = 1;
 const IS_RECORDER_RECORDING = 2;
 const IS_RECORDER_STOPPED = 0;
 
+const audioContext = new AudioContext();
+
+
 function newRecorderInstance(aCallback, callbackTable) { return new FlutterSoundRecorder(aCallback, callbackTable); }
 
 
@@ -181,9 +184,9 @@ class FlutterSoundRecorder {
                 mediaStream = await navigator.mediaDevices.getUserMedia({ audio: true, video: false });
                 me.mediaStream = mediaStream;
 
-                const audioContext = new AudioContext();
-                const _audioSource = audioContext.createMediaStreamSource(mediaStream);
-                const analyser = audioContext.createAnalyser();
+                this.audioContext = new AudioContext();
+                const _audioSource = this.audioContext.createMediaStreamSource(mediaStream);
+                const analyser = this.audioContext.createAnalyser();
                 // todo: review if this values are right (set to mimic a behaviour closest to that of Android)
                 analyser.fftSize = 512;
                 analyser.minDecibels = -110;
@@ -367,6 +370,11 @@ class FlutterSoundRecorder {
                         this.mediaStream.getTracks().forEach(track => track.stop());
                         this.mediaStream = null;
                 }
+                  // Close the audioContext if it exists
+                if (this.audioContext != null) {
+                        this.audioContext.close();
+                        this.audioContext = null;
+                }
                 this.callbackTable[CB_recorder_log](this.callback, DBG, 'JS:<--- stop()');
         }
 
@@ -383,6 +391,11 @@ class FlutterSoundRecorder {
                 if (this.mediaStream != null) {
                         this.mediaStream.getTracks().forEach(track => track.stop());
                         this.mediaStream = null;
+                }
+                  // Close the audioContext if it exists
+                if (this.audioContext != null) {
+                        this.audioContext.close();
+                        this.audioContext = null;
                 }
                 this.callbackTable[CB_recorder_log](this.callback, DBG, "JS:<--- stopRecorder");
         }


### PR DESCRIPTION
This fix addresses an issue where, after recording approximately 10 audio clips, the microphone would stop functioning.

#### Root Cause:
The issue stemmed from the `starRecorder` function creating a new `AudioContext` with each recording session, without properly closing the previous ones. Some browsers, such as Google Chrome, impose a limit on the number of active `AudioContexts`—typically around 10. Once this limit is exceeded, further recordings are blocked, and the following JavaScript error is thrown:

`The AudioContext encountered an error from the audio device or the WebAudio renderer.`

Additionally, while profiling in Google Chrome, the error message:

`Number of opened output audio streams 10 exceeded the max allowed number 10`

confirmed that the issue was related to the excessive number of `AudioContexts` being opened without closure.

#### Solution:
The fix ensures that `stopRecorder` properly closes the `AudioContext` initiated by `startRecorder`, preventing the accumulation of open contexts.

#### Device-Specific Reproduction:
While this bug did not appear on all browsers or devices, it was reproducible on the Google Chrome app running on an Android Samsung Galaxy A55 (128GB).
